### PR TITLE
Creation of elbow_calibration_set_to_eeprom

### DIFF
--- a/arm_tests/arm_tests.ino
+++ b/arm_tests/arm_tests.ino
@@ -1,3 +1,4 @@
+#include <EEPROMex.h>
 #include <Servo.h>
 #include <Filters.h>
 #define NUM_READS 100 // number of read measures to process the signal
@@ -27,15 +28,18 @@
 #define LC_BIT_MAX  1023
 #define LC_NEWTON_MIN 1.475*G
 #define LC_NEWTON_MAX 50*G
+
 //Definitions for the elbow
-#define FULL_OPEN_ELBOW 41  // value in PWM to full open the elbow angle
-#define FULL_OPEN_COMPEN 3 // to compensante the Hysteresis in the elbow
-#define FULL_CLOSE_ELBOW 0  // value in PWM to close the elbow angle
-#define MAX_ELBOW_ANGLE 120*PI/180 // Max aperture of the elbow angle measure externally
-#define MIN_ELBOW_ANGLE 40*PI/180  // Min aperture of the elbow angle, measured exernally
-#define ANGLE_VPOT_MAX  165       // Value in bits of the vpot when is the maximum angle on the elbow
-#define ANGLE_VPOT_COMPEN 6     // to compensate the Hysteresis no angle measure
-#define ANGLE_VPOT_MIN  23       // Value in bits of the vpot when is the min angle on the elbow
+//Utilisar read
+int FULL_OPEN_ELBOW   = EEPROM.readInt(0);   // 41;  // value in PWM to full open the elbow angle
+int FULL_OPEN_COMPEN  = EEPROM.readInt(2);  // 3 ;// to compensante the Hysteresis in the elbow
+int FULL_CLOSE_ELBOW  = 0 ;           // value in PWM to close the elbow angle
+float MAX_ELBOW_ANGLE = EEPROM.readInt(4)*PI/180;  //120*PI/180;   // Max aperture of the elbow angle measure externally
+float MIN_ELBOW_ANGLE = EEPROM.readInt(6)*PI/180;  //40*PI/180;    // Min aperture of the elbow angle, measured exernally
+int ANGLE_VPOT_MAX    = EEPROM.readInt(8);  // 165 ;      // Value in bits of the vpot when is the maximum angle on the elbow
+int ANGLE_VPOT_COMPEN = EEPROM.readInt(10);  // 6 ;    // to compensate the Hysteresis no angle measure
+int ANGLE_VPOT_MIN    = EEPROM.readInt(12);  // 23  ;     // Value in bits of the vpot when is the min angle on the elbow
+
 //Definitions for the Arm
 #define DCA 0.0575    //Distance of the arm clamping
 #define DCF 0.0475    //Distance of the forearm clamping
@@ -95,7 +99,7 @@ int menu_var=-1;
 //subject defintions
 float La=0.28;
 float Lf=0.26;
-float Lh=0.10;    
+float Lh=0.10;
 
 //definitions to calibrate control law
 float Sgm_left_lim=-2;    //defintion about the left limit of the sigmoid function on the control law

--- a/arm_tests/calibrations.ino
+++ b/arm_tests/calibrations.ino
@@ -157,7 +157,7 @@ void calibrate_elbow_angle()
     Serial.println("Choose an action for calibration:");
     Serial.println("  1) Free movement of elbow PWM bits, and measures");
     Serial.println("  2) Confirmation to test choosen values for elbow angle movement calibration");
-    Serial.println("  3) Under construction");
+    Serial.println("  3) Send Calibration values to EEPROM");
     Serial.println(" -1) To exit calibration tests");
     int menu_value=0;
     do
@@ -182,7 +182,7 @@ void calibrate_elbow_angle()
         elbow_calibration_menu2();
         break;
       case 3:
-
+        elbow_calibration_set_to_eeprom();
         break;
     }
   }while(1);
@@ -238,7 +238,7 @@ void elbow_calibration_menu2()
   float Traj_x_min;
   float Traj_x_max;
   float vpot_max_function;
-  
+
 
   Serial.println("For test enter, full open elbow value(bits), max open elbow (degrees), min open elbow (degrees) and desired angle");
   Serial.println("Enter -1 to exit to the calibration menu");
@@ -328,9 +328,9 @@ void LS_parameters_finder ()
   float loadcell_rawfilt;
   float angle_ant=0;
   cont_high = cont_low=0;
-    
+
   //initializing the position of the test
-  do{    
+  do{
   angle_ant=angle_rawfilt;
   servooldg.write(FULL_CLOSE_ELBOW);
   delay(500);
@@ -402,7 +402,7 @@ void LS_parameters_finder ()
       delayMicroseconds(500);
   }
   }while(cont_high>=0);
-    
+
 }
 
 void LS_parameters_saver()
@@ -445,3 +445,90 @@ void LS_parameters_saver()
 
 }
 
+
+void elbow_calibration_set_to_eeprom()
+{
+  int full_open_elbow   ;
+  int full_open_compen  ;
+  int max_elbow_angle   ;
+  int min_elbow_angle   ;
+  int angle_vpot_max    ;
+  int angle_vpot_compen ;
+  int angle_vpot_min    ;
+
+  //Ask user input to save in EEPROM
+  Serial.println("Insert the values you want to save to EEPROM in the following order Or '-1' to exit:");
+  Serial.println("full_open_elbow,full_open_compen,max_elbow_angle(in degrees),min_elbow_angle(in degrees),angle_vpot_max,angle_vpot_compen,angle_vpot_min");
+  do
+  {
+    // Treat input
+    if (Serial.available())
+    {
+      full_open_elbow   = Serial.parseInt();
+      if(full_open_elbow<0)
+      {
+        break;
+      }
+      full_open_compen  = Serial.parseInt();
+      max_elbow_angle   = Serial.parseInt();
+      min_elbow_angle   = Serial.parseInt();
+      angle_vpot_max    = Serial.parseInt();
+      angle_vpot_compen = Serial.parseInt();
+      angle_vpot_min    = Serial.parseInt();
+
+
+      if (Serial.read()=='\n'){}
+      Serial.println("Are you certain these are the values you want to save in EEPROM? (y/n)");
+      Serial.print(full_open_elbow);
+      Serial.print(',');
+      Serial.print(full_open_compen);
+      Serial.print(',');
+      Serial.print(max_elbow_angle);
+      Serial.print(',');
+      Serial.print(min_elbow_angle);
+      Serial.print(',');
+      Serial.print(angle_vpot_max);
+      Serial.print(',');
+      Serial.print(angle_vpot_compen);
+      Serial.print(',');
+      Serial.println(angle_vpot_min);
+
+      while (menu_var!=89 && menu_var!=121 && menu_var!=78 && menu_var!=110)
+      {
+        menu_var=Serial.read();
+      }
+      if(menu_var==89 || menu_var==121)
+      {
+        // Save in EEPROM
+        EEPROM.updateInt(0, full_open_elbow);
+        EEPROM.updateInt(2, full_open_compen);
+        EEPROM.updateInt(4, max_elbow_angle);
+        EEPROM.updateInt(6, min_elbow_angle);
+        EEPROM.updateInt(8, angle_vpot_max);
+        EEPROM.updateInt(10, angle_vpot_compen);
+        EEPROM.updateInt(12, angle_vpot_min);
+
+        Serial.println("New Data Saved");
+        // Read values saved in EEPROM
+        FULL_OPEN_ELBOW   = EEPROM.readInt(0);
+        FULL_OPEN_COMPEN  = EEPROM.readInt(2);
+        MAX_ELBOW_ANGLE   = EEPROM.readInt(4)*PI/180;
+        MIN_ELBOW_ANGLE   = EEPROM.readInt(6)*PI/180;
+        ANGLE_VPOT_MAX    = EEPROM.readInt(8);
+        ANGLE_VPOT_COMPEN = EEPROM.readInt(10);
+        ANGLE_VPOT_MIN    = EEPROM.readInt(12);
+        Serial.println("New Data Loaded");
+        Serial.println("");
+        break;
+      }
+      if(menu_var==78 || menu_var==110)
+      {
+        Serial.println("Insert the values you want to save to EEPROM in the following order:");
+        Serial.println("full_open_elbow,full_open_compen,max_elbow_angle(in degrees),min_elbow_angle(in degrees),angle_vpot_max,angle_vpot_compen,angle_vpot_min");
+        menu_var=0;
+        continue;
+      }
+    }
+  }while(1);
+  menu_var=0;
+}


### PR DESCRIPTION
Now is possible set values to EEPROM. It's not necessary to recompile
the program to change this variables:

FULL_OPEN_ELBOW
FULL_OPEN_COMPEN
FULL_CLOSE_ELBOW
MAX_ELBOW_ANGLE
MIN_ELBOW_ANGLE
ANGLE_VPOT_MAX
ANGLE_VPOT_COMPEN
ANGLE_VPOT_MIN
